### PR TITLE
Enhance featured product card customization

### DIFF
--- a/featured-product-cards (1).liquid
+++ b/featured-product-cards (1).liquid
@@ -15,8 +15,14 @@
       { "type": "text", "id": "title", "label": "Title", "default": "Fighter | i3-12100F | RTX 3050" },
       { "type": "textarea", "id": "subtitle", "label": "One-line specs", "default": "16GB • 1TB NVMe • Wi-Fi 6" },
       { "type": "image_picker", "id": "image", "label": "Image" },
+      { "type": "product", "id": "product", "label": "Product" },
       { "type": "url", "id": "learn_url", "label": "Learn more link", "default": "/" },
-      { "type": "url", "id": "buy_url", "label": "Buy now link", "default": "/" }
+      { "type": "url", "id": "buy_url", "label": "Buy now link", "default": "/" },
+      { "type": "select", "id": "image_fit", "label": "Image fit", "default": "cover", "options": [
+        { "value": "cover", "label": "Cover" },
+        { "value": "contain", "label": "Contain" }
+      ] },
+      { "type": "range", "id": "image_scale", "label": "Image zoom", "min": 0.5, "max": 1.5, "step": 0.01, "default": 1 }
     ]
   }
 ],
@@ -36,28 +42,39 @@
 
   <div class="ux-grid">
     {% for block in section.blocks %}
+      {% assign card_product = block.settings.product %}
+      {% assign title = block.settings.title %}
+      {% assign subtitle = block.settings.subtitle %}
+      {% assign learn_url = block.settings.learn_url %}
+      {% assign buy_url = block.settings.buy_url %}
       {% assign img = block.settings.image %}
+      {% if card_product != blank %}
+        {% assign title = block.settings.title | default: card_product.title %}
+        {% assign img = block.settings.image | default: card_product.featured_image %}
+        {% assign learn_url = block.settings.learn_url | default: card_product.url %}
+        {% assign buy_url = block.settings.buy_url | default: card_product.url %}
+      {% endif %}
       <article class="ux-card" {{ block.shopify_attributes }}>
         {% if block.settings.kicker != blank %}<p class="ux-kicker">{{ block.settings.kicker }}</p>{% endif %}
-        <h3 class="ux-title">{{ block.settings.title }}</h3>
-        {% if block.settings.subtitle != blank %}<p class="ux-sub">{{ block.settings.subtitle }}</p>{% endif %}
+        <h3 class="ux-title">{{ title }}</h3>
+        {% if subtitle != blank %}<p class="ux-sub">{{ subtitle }}</p>{% endif %}
 
         <div class="ux-cta">
-          {% if block.settings.learn_url != blank %}
-            <a href="{{ block.settings.learn_url }}" class="ux-link">Learn More</a>
+          {% if learn_url != blank %}
+            <a href="{{ learn_url }}" class="ux-link">Learn More</a>
           {% endif %}
-          {% if block.settings.buy_url != blank %}
-            <a href="{{ block.settings.buy_url }}" class="ux-link">Buy Now</a>
+          {% if buy_url != blank %}
+            <a href="{{ buy_url }}" class="ux-btn">Buy Now</a>
           {% endif %}
         </div>
 
         {% if img != blank %}
-  <a class="ux-media" href="{{ block.settings.learn_url | default: block.settings.buy_url | default: '#' }}">
+  <a class="ux-media" href="{{ learn_url | default: buy_url | default: '#' }}" style="--ux-image-fit: {{ block.settings.image_fit }}; --ux-image-scale: {{ block.settings.image_scale }}; --ux-image-scale-hover: {{ block.settings.image_scale | plus: 0.03 }};">
     {{-
       img
       | image_url: width: 1200
       | image_tag:
-        alt: block.settings.title,
+        alt: title,
         loading: 'lazy',
         widths: '600,900,1200',
         sizes: '(max-width: 700px) 100vw, (max-width: 1100px) 50vw, 33vw',
@@ -167,12 +184,12 @@
 #shopify-section-{{ section.id }} .ux-media img{
   width: 100%;
   height: 100%;
-  object-fit: cover; /* swap to 'contain' if you want full product in frame */
-  transform: scale(1.01);
+  object-fit: var(--ux-image-fit, cover);
+  transform: scale(var(--ux-image-scale, 1));
   transition: transform .5s ease;
 }
 #shopify-section-{{ section.id }} .ux-card:hover .ux-media img{
-  transform: scale(1.03);
+  transform: scale(var(--ux-image-scale-hover, 1.03));
 }
 
 /* ---------- CTAs ---------- */
@@ -199,5 +216,18 @@
 }
 #shopify-section-{{ section.id }} .ux-link:hover{
   color: var(--ux-ink-mute);
+}
+#shopify-section-{{ section.id }} .ux-btn{
+  background: var(--ux-accent);
+  color: #fff;
+  font-weight: 600;
+  font-size: .95rem;
+  text-decoration: none;
+  padding: 8px 18px;
+  border-radius: 6px;
+  transition: background .2s ease;
+}
+#shopify-section-{{ section.id }} .ux-btn:hover{
+  background: var(--ux-ink-mute);
 }
 </style>


### PR DESCRIPTION
## Summary
- allow linking to a real product and defaulting card content from it
- add image fit and zoom settings for better control of product imagery
- style "Buy Now" as an accent button so it stands out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c683476098832db910885b19fd03a6